### PR TITLE
Use skimage.filters and alias scipy.ndimage as ndi not nd

### DIFF
--- a/lectures/4_segmentation.ipynb
+++ b/lectures/4_segmentation.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
     "\n",
     "<img src=\"../2014-scipy/images/terminator-vision.png\" width=\"700px\"/>\n",
     "\n",
-    "In `scikit-image`, you can find segmentation functions in the `segmentation` package, with one exception: the `watershed` function is in `morphology`, because it's a bit of both. We'll use two algorithms, SLIC and watershed and discuss applications of each.\n",
+    "In `scikit-image`, you can find segmentation functions in the `segmentation` package, with one exception: the `watershed` function is in `morphology`, because it's a bit of both. We'll use two algorithms, SLIC and watershed, and discuss applications of each.\n",
     "\n",
     "There are two kinds of segmentation: *contrast-based* and *boundary-based*. The first is used when the regions of the image you are trying to divide have different characteristics, such as a red flower on a green background. The second is used when you want to segment an image in which borders between objects are prominent, but objects themselves are not very distinct. For example, a pile of oranges.\n",
     "\n",
@@ -262,7 +262,8 @@
    },
    "outputs": [],
    "source": [
-    "from skimage import data, filter as filters\n",
+    "from skimage import data\n",
+    "from skimage import filters\n",
     "from matplotlib import pyplot as plt, cm"
    ]
   },
@@ -298,12 +299,12 @@
    "outputs": [],
    "source": [
     "from skimage.morphology import watershed\n",
-    "from scipy import ndimage as nd\n",
+    "from scipy import ndimage as ndi\n",
     "\n",
     "x = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])\n",
     "y = np.array([1, 0, 1, 2, 1, 3, 2, 0, 2, 4, 1, 0])\n",
     "\n",
-    "seeds = nd.label(y == 0)[0]\n",
+    "seeds = ndi.label(y == 0)[0]\n",
     "seed_positions = np.argwhere(seeds)[:, 0]\n",
     "\n",
     "print(\"Seeds:\", seeds)\n",
@@ -356,13 +357,12 @@
    },
    "outputs": [],
    "source": [
-    "from scipy import ndimage as nd\n",
     "threshold = 0.4\n",
     "\n",
     "# Euclidean distance transform\n",
     "# How far do we ave to travel from a non-edge to find an edge?\n",
     "non_edges = (edges < threshold)\n",
-    "distance_from_edge = nd.distance_transform_edt(non_edges)\n",
+    "distance_from_edge = ndi.distance_transform_edt(non_edges)\n",
     "\n",
     "plt.imshow(distance_from_edge, cmap='gray');"
    ]
@@ -391,7 +391,7 @@
     "\n",
     "peaks_image = np.zeros(coins.shape, np.bool)\n",
     "peaks_image[tuple(np.transpose(peaks))] = True\n",
-    "seeds, num_seeds = nd.label(peaks_image)\n",
+    "seeds, num_seeds = ndi.label(peaks_image)\n",
     "\n",
     "plt.imshow(edges, cmap='gray')\n",
     "plt.plot(peaks[:, 1], peaks[:, 0], 'ro');\n",
@@ -478,115 +478,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<style>\n",
-       ".rendered_html {\n",
-       "    font-family: Georgia, serif;\n",
-       "    font-size: 130%;\n",
-       "    line-height: 1.5;\n",
-       "}\n",
-       "\n",
-       ".input {\n",
-       "    width: 930px;\n",
-       "}\n",
-       "\n",
-       ".inner_cell {\n",
-       "    width: 800px;\n",
-       "}\n",
-       "\n",
-       ".code_cell {\n",
-       "    width: 800px;\n",
-       "}\n",
-       "\n",
-       ".CodeMirror-sizer {\n",
-       "}\n",
-       "\n",
-       "hr {\n",
-       "    border: 1px solid #DDD;\n",
-       "}\n",
-       "\n",
-       ".rendered_html h1 {\n",
-       "    margin: 0.25em 0em 0.5em;\n",
-       "    font-family: sans-serif;\n",
-       "    color: #015C9C;\n",
-       "    text-align: center;\n",
-       "    line-height: 1.2;\n",
-       "    page-break-before: always;\n",
-       "}\n",
-       "\n",
-       ".rendered_html h2 {\n",
-       "    margin: 1.1em 0em 0.5em;\n",
-       "    font-family: sans-serif;\n",
-       "    color: #26465D;\n",
-       "    line-height: 1.2;\n",
-       "}\n",
-       "\n",
-       ".rendered_html h3 {\n",
-       "    font-family: sans-serif;\n",
-       "    margin: 1.1em 0em 0.5em;\n",
-       "    color: #002845;\n",
-       "    line-height: 1.2;\n",
-       "}\n",
-       "\n",
-       ".rendered_html li {\n",
-       "    line-height: 1.5;\n",
-       "}\n",
-       "\n",
-       ".CodeMirror-lines {\n",
-       "    font-size: 110%;\n",
-       "    line-height: 1.4em;\n",
-       "    font-family: DejaVu Sans Mono, Consolas, Ubuntu, monospace;\n",
-       "}\n",
-       "\n",
-       "h1.bigtitle {\n",
-       "    margin: 4cm 1cm 4cm 1cm;\n",
-       "    font-size: 300%;\n",
-       "}\n",
-       "\n",
-       "h3.point {\n",
-       "    font-size: 200%;\n",
-       "    text-align: center;\n",
-       "    margin: 2em 0em 2em 0em;\n",
-       "    #26465D\n",
-       "}\n",
-       "\n",
-       ".logo {\n",
-       "    margin: 20px 0 20px 0;\n",
-       "}\n",
-       "\n",
-       "a.anchor-link {\n",
-       "    display: none;\n",
-       "}\n",
-       "\n",
-       "h1.title {\n",
-       "    font-size: 250%;\n",
-       "}\n",
-       "\n",
-       ".exercize {\n",
-       "    color: #738;\n",
-       "}\n",
-       "\n",
-       "h2 .exercize {\n",
-       "    font-style: italic;\n",
-       "}\n",
-       "\n",
-       "</style>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML at 0x7fe2e0687ac8>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%reload_ext load_style\n",
     "%load_style ../themes/tutorial.css"
@@ -604,21 +500,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This avoids a warning which was otherwise thrown because of `skimage.filter` being imported then aliased to `filters`. Now we just import `filters`.

Also, I strongly prefer the convention of `import skimage.ndimage as ndi` to better differentiate from the usual NumPy `np` namespace.