### PR TITLE
Update panorama lecture

### DIFF
--- a/lectures/adv3_panorama-stitching.ipynb
+++ b/lectures/adv3_panorama-stitching.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import division, print_function\n",
@@ -35,9 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -83,9 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage import io\n",
@@ -103,9 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# compare(...)\n"
@@ -138,9 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.color import rgb2gray\n",
@@ -152,9 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# View the results using compare()\n"
@@ -189,9 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.feature import ORB\n",
@@ -219,9 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.feature import match_descriptors\n",
@@ -241,9 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.feature import plot_matches\n",
@@ -265,9 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 1, figsize=(12, 12))\n",
@@ -301,9 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.transform import ProjectiveTransform\n",
@@ -338,9 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Use plot_matches as before, but select only good matches with fancy indexing\n",
@@ -350,9 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Use plot_matches as before, but select only good matches with fancy indexing\n",
@@ -383,9 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.transform import SimilarityTransform\n",
@@ -433,9 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.transform import warp\n",
@@ -462,9 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Warp pano0 to pano1\n",
@@ -486,9 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Warp pano2 to pano1\n",
@@ -510,9 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "compare(pano0_warped, pano1_warped, pano2_warped, figsize=(12, 10));"
@@ -541,9 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Add the three warped images together. This could create dtype overflows!\n",
@@ -554,9 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Track the overlap by adding the masks together\n",
@@ -566,9 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Normalize through division by `overlap` - but ensure the minimum is 1\n",
@@ -585,9 +543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -600,9 +556,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "\n",
     "---\n",
@@ -630,7 +584,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#5. Stitching images along a minimum-cost path\n",
+    "# 5. Stitching images along a minimum-cost path\n",
     "\n",
     "Let's step back a moment and consider: Is it even reasonable to blend pixels?\n",
     "\n",
@@ -640,9 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -701,21 +653,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "ymax = output_shape[1] - 1\n",
-    "xmax = output_shape[0] - 1\n",
+    "rmax = output_shape[0] - 1\n",
+    "cmax = output_shape[1] - 1\n",
     "\n",
     "# Start anywhere along the top and bottom, left of center.\n",
-    "mask_pts01 = [[0,    ymax // 3],\n",
-    "              [xmax, ymax // 3]]\n",
+    "mask_pts01 = [[0,    cmax // 3],\n",
+    "              [rmax, cmax // 3]]\n",
     "\n",
     "# Start anywhere along the top and bottom, right of center.\n",
-    "mask_pts12 = [[0,    2*ymax // 3],\n",
-    "              [xmax, 2*ymax // 3]]"
+    "mask_pts12 = [[0,    2*cmax // 3],\n",
+    "              [rmax, 2*cmax // 3]]"
    ]
   },
   {
@@ -732,76 +682,79 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from skimage.measure import label\n",
+    "from skimage.morphology import flood_fill\n",
     "\n",
     "def generate_costs(diff_image, mask, vertical=True, gradient_cutoff=2.):\n",
     "    \"\"\"\n",
     "    Ensures equal-cost paths from edges to region of interest.\n",
-    "    \n",
+    "\n",
     "    Parameters\n",
     "    ----------\n",
-    "    diff_image : (M, N) ndarray of floats\n",
+    "    diff_image : ndarray of floats\n",
     "        Difference of two overlapping images.\n",
-    "    mask : (M, N) ndarray of bools\n",
+    "    mask : ndarray of bools\n",
     "        Mask representing the region of interest in ``diff_image``.\n",
     "    vertical : bool\n",
     "        Control operation orientation.\n",
     "    gradient_cutoff : float\n",
     "        Controls how far out of parallel lines can be to edges before\n",
     "        correction is terminated. The default (2.) is good for most cases.\n",
-    "        \n",
+    "\n",
     "    Returns\n",
     "    -------\n",
-    "    costs_arr : (M, N) ndarray of floats\n",
+    "    costs_arr : ndarray of floats\n",
     "        Adjusted costs array, ready for use.\n",
     "    \"\"\"\n",
     "    if vertical is not True:\n",
     "        return tweak_costs(diff_image.T, mask.T, vertical=vertical,\n",
     "                           gradient_cutoff=gradient_cutoff).T\n",
-    "    \n",
+    "\n",
     "    # Start with a high-cost array of 1's\n",
     "    costs_arr = np.ones_like(diff_image)\n",
-    "    \n",
+    "\n",
     "    # Obtain extent of overlap\n",
     "    row, col = mask.nonzero()\n",
     "    cmin = col.min()\n",
     "    cmax = col.max()\n",
+    "    shape = mask.shape\n",
     "\n",
     "    # Label discrete regions\n",
+    "    labels = mask.copy().astype(np.uint8)\n",
     "    cslice = slice(cmin, cmax + 1)\n",
-    "    labels = label(mask[:, cslice])\n",
-    "    \n",
+    "    submask = np.ascontiguousarray(labels[:, cslice])\n",
+    "    submask = flood_fill(submask, (0, 0), 2)\n",
+    "    submask = flood_fill(submask, (shape[0]-1, 0), 3)\n",
+    "    labels[:, cslice] = submask\n",
+    "\n",
     "    # Find distance from edge to region\n",
-    "    upper = (labels == 0).sum(axis=0)\n",
-    "    lower = (labels == 2).sum(axis=0)\n",
-    "    \n",
+    "    upper = (labels == 2).sum(axis=0).astype(np.float64)\n",
+    "    lower = (labels == 3).sum(axis=0).astype(np.float64)\n",
+    "\n",
     "    # Reject areas of high change\n",
-    "    ugood = np.abs(np.gradient(upper)) < gradient_cutoff\n",
-    "    lgood = np.abs(np.gradient(lower)) < gradient_cutoff\n",
-    "    \n",
+    "    ugood = np.abs(np.gradient(upper[cslice])) < gradient_cutoff\n",
+    "    lgood = np.abs(np.gradient(lower[cslice])) < gradient_cutoff\n",
+    "\n",
     "    # Give areas slightly farther from edge a cost break\n",
-    "    costs_upper = np.ones_like(upper, dtype=np.float64)\n",
-    "    costs_lower = np.ones_like(lower, dtype=np.float64)\n",
-    "    costs_upper[ugood] = upper.min() / np.maximum(upper[ugood], 1)\n",
-    "    costs_lower[lgood] = lower.min() / np.maximum(lower[lgood], 1)\n",
-    "    \n",
+    "    costs_upper = np.ones_like(upper)\n",
+    "    costs_lower = np.ones_like(lower)\n",
+    "    costs_upper[cslice][ugood] = upper[cslice].min() / np.maximum(upper[cslice][ugood], 1)\n",
+    "    costs_lower[cslice][lgood] = lower[cslice].min() / np.maximum(lower[cslice][lgood], 1)\n",
+    "\n",
     "    # Expand from 1d back to 2d\n",
     "    vdist = mask.shape[0]\n",
     "    costs_upper = costs_upper[np.newaxis, :].repeat(vdist, axis=0)\n",
     "    costs_lower = costs_lower[np.newaxis, :].repeat(vdist, axis=0)\n",
-    "    \n",
+    "\n",
     "    # Place these in output array\n",
-    "    costs_arr[:, cslice] = costs_upper * (labels == 0)\n",
-    "    costs_arr[:, cslice] +=  costs_lower * (labels == 2)\n",
-    "    \n",
+    "    costs_arr[:, cslice] = costs_upper[:, cslice] * (labels[:, cslice] == 2)\n",
+    "    costs_arr[:, cslice] +=  costs_lower[:, cslice] * (labels[:, cslice] == 3)\n",
+    "\n",
     "    # Finally, place the difference image\n",
     "    costs_arr[mask] = diff_image[mask]\n",
-    "    \n",
+    "\n",
     "    return costs_arr"
    ]
   },
@@ -815,9 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Start with the absolute value of the difference image.\n",
@@ -836,15 +787,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Set top and bottom edges to zero in `costs01`\n",
-    "# Remember (row, col) indexing!\n",
-    "costs01[0, :] = 0\n",
-    "costs01[-1, :] = 0"
+    "# Remember (row, col) indexing!\n"
    ]
   },
   {
@@ -857,9 +804,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(15, 12))\n",
@@ -888,9 +833,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.graph import route_through_array\n",
@@ -916,9 +859,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -965,9 +906,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Start with an array of zeros and place the path\n",
@@ -985,9 +924,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -1008,15 +945,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from skimage.measure import label\n",
+    "from skimage.morphology import flood_fill\n",
     "\n",
-    "# Labeling starts with zero at point (0, 0)\n",
-    "mask0 = (label(mask0, connectivity=1, background=-1) == 1)\n",
+    "# Labeling starts with one at point (0, 0)\n",
+    "mask0 = flood_fill(mask0, (0, 0), 1, connectivity=1)\n",
     "\n",
     "# The result\n",
     "plt.imshow(mask0, cmap='gray');"
@@ -1028,15 +963,16 @@
    "source": [
     "Looks great!\n",
     "\n",
+    "\n",
+    "### Rinse and repeat\n",
+    "\n",
     "Apply the same principles to images 1 and 2: first, build the cost array"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Start with the absolute value of the difference image.\n",
@@ -1060,9 +996,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "costs12[mask0 > 0] = 1"
@@ -1078,9 +1012,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(8, 8))\n",
@@ -1099,9 +1031,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Arguments are:\n",
@@ -1125,9 +1055,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -1151,9 +1079,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mask2 = np.zeros_like(pano0_warped, dtype=np.uint8)\n",
@@ -1170,9 +1096,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mask2 = (label(mask2, connectivity=1, background=-1) == 3)\n",
@@ -1193,12 +1117,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "mask1 = ~(mask0 | mask2).astype(bool)"
+    "mask1 = ~(mask0.astype(np.bool) | mask2.astype(np.bool))"
    ]
   },
   {
@@ -1211,9 +1133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def add_alpha(img, mask=None):\n",
@@ -1248,9 +1168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pano0_final = add_alpha(pano0_warped, mask0)\n",
@@ -1272,9 +1190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -1302,7 +1218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#Bonus round: now, in color!\n",
+    "# Bonus round: now, in color!\n",
     "\n",
     "We converted to grayscale for ORB feature detection, back in the initial **preprocessing** steps. Since we stored our transforms and masks, adding color is straightforward!\n",
     "\n",
@@ -1312,9 +1228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Identical transforms as before, except\n",
@@ -1340,9 +1254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pano0_final = add_alpha(pano0_color, mask0)\n",
@@ -1360,9 +1272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -1386,9 +1296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.color import gray2rgb\n",
@@ -1410,9 +1318,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "\n",
     "---\n",
@@ -1445,9 +1351,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "\n",
     "---\n",
@@ -1457,115 +1361,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<style>\n",
-       ".rendered_html {\n",
-       "    font-family: Georgia, serif;\n",
-       "    font-size: 130%;\n",
-       "    line-height: 1.5;\n",
-       "}\n",
-       "\n",
-       ".input {\n",
-       "    width: 930px;\n",
-       "}\n",
-       "\n",
-       ".inner_cell {\n",
-       "    width: 800px;\n",
-       "}\n",
-       "\n",
-       ".code_cell {\n",
-       "    width: 800px;\n",
-       "}\n",
-       "\n",
-       ".CodeMirror-sizer {\n",
-       "}\n",
-       "\n",
-       "hr {\n",
-       "    border: 1px solid #DDD;\n",
-       "}\n",
-       "\n",
-       ".rendered_html h1 {\n",
-       "    margin: 0.25em 0em 0.5em;\n",
-       "    font-family: sans-serif;\n",
-       "    color: #015C9C;\n",
-       "    text-align: center;\n",
-       "    line-height: 1.2;\n",
-       "    page-break-before: always;\n",
-       "}\n",
-       "\n",
-       ".rendered_html h2 {\n",
-       "    margin: 1.1em 0em 0.5em;\n",
-       "    font-family: sans-serif;\n",
-       "    color: #26465D;\n",
-       "    line-height: 1.2;\n",
-       "}\n",
-       "\n",
-       ".rendered_html h3 {\n",
-       "    font-family: sans-serif;\n",
-       "    margin: 1.1em 0em 0.5em;\n",
-       "    color: #002845;\n",
-       "    line-height: 1.2;\n",
-       "}\n",
-       "\n",
-       ".rendered_html li {\n",
-       "    line-height: 1.5;\n",
-       "}\n",
-       "\n",
-       ".CodeMirror-lines {\n",
-       "    font-size: 110%;\n",
-       "    line-height: 1.4em;\n",
-       "    font-family: DejaVu Sans Mono, Consolas, Ubuntu, monospace;\n",
-       "}\n",
-       "\n",
-       "h1.bigtitle {\n",
-       "    margin: 4cm 1cm 4cm 1cm;\n",
-       "    font-size: 300%;\n",
-       "}\n",
-       "\n",
-       "h3.point {\n",
-       "    font-size: 200%;\n",
-       "    text-align: center;\n",
-       "    margin: 2em 0em 2em 0em;\n",
-       "    #26465D\n",
-       "}\n",
-       "\n",
-       ".logo {\n",
-       "    margin: 20px 0 20px 0;\n",
-       "}\n",
-       "\n",
-       "a.anchor-link {\n",
-       "    display: none;\n",
-       "}\n",
-       "\n",
-       "h1.title {\n",
-       "    font-size: 250%;\n",
-       "}\n",
-       "\n",
-       ".exercize {\n",
-       "    color: #738;\n",
-       "}\n",
-       "\n",
-       "h2 .exercize {\n",
-       "    font-style: italic;\n",
-       "}\n",
-       "\n",
-       "</style>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "%reload_ext load_style\n",
     "%load_style ../themes/tutorial.css"
@@ -1588,9 +1386,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/lectures/solutions/adv3_panorama-stitching-solution.ipynb
+++ b/lectures/solutions/adv3_panorama-stitching-solution.ipynb
@@ -1256,7 +1256,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then apply the custom alpha channel masks"
+    "Apply the custom alpha channel masks"
    ]
   },
   {

--- a/lectures/solutions/adv3_panorama-stitching-solution.ipynb
+++ b/lectures/solutions/adv3_panorama-stitching-solution.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import division, print_function\n",
@@ -35,9 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -83,9 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import skimage.io as io\n",
@@ -103,9 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "compare(*pano_imgs, figsize=(12, 10))"
@@ -138,9 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.color import rgb2gray\n",
@@ -151,9 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# View the results\n",
@@ -182,9 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.feature import ORB\n",
@@ -220,9 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.feature import match_descriptors\n",
@@ -242,9 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.feature import plot_matches\n",
@@ -265,9 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 1, figsize=(15, 12))\n",
@@ -300,9 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.transform import ProjectiveTransform\n",
@@ -337,9 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 1, figsize=(15, 12))\n",
@@ -353,9 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(1, 1, figsize=(15, 12))\n",
@@ -390,9 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.transform import SimilarityTransform\n",
@@ -440,9 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.transform import warp\n",
@@ -469,9 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Warp pano0 (left) to pano1\n",
@@ -493,9 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Warp pano2 (right) to pano1 \n",
@@ -517,9 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "compare(pano0_warped, pano1_warped, pano2_warped, figsize=(12, 10));"
@@ -548,9 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Add the three images together. This could create dtype overflows!\n",
@@ -561,9 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Track the overlap by adding the masks together\n",
@@ -575,9 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Normalize through division by `overlap` - but ensure the minimum is 1\n",
@@ -594,9 +552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -609,9 +565,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "\n",
     "---\n",
@@ -649,9 +603,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(15,12))\n",
@@ -710,21 +662,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "ymax = output_shape[1] - 1\n",
-    "xmax = output_shape[0] - 1\n",
+    "rmax = output_shape[0] - 1\n",
+    "cmax = output_shape[1] - 1\n",
     "\n",
     "# Start anywhere along the top and bottom, left of center.\n",
-    "mask_pts01 = [[0,    ymax // 3],\n",
-    "              [xmax, ymax // 3]]\n",
+    "mask_pts01 = [[0,    cmax // 3],\n",
+    "              [rmax, cmax // 3]]\n",
     "\n",
     "# Start anywhere along the top and bottom, right of center.\n",
-    "mask_pts12 = [[0,    2*ymax // 3],\n",
-    "              [xmax, 2*ymax // 3]]"
+    "mask_pts12 = [[0,    2*cmax // 3],\n",
+    "              [rmax, 2*cmax // 3]]"
    ]
   },
   {
@@ -741,17 +691,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from skimage.measure import label\n",
+    "from skimage.morphology import flood_fill\n",
     "\n",
     "def generate_costs(diff_image, mask, vertical=True, gradient_cutoff=2.):\n",
     "    \"\"\"\n",
     "    Ensures equal-cost paths from edges to region of interest.\n",
-    "    \n",
+    "\n",
     "    Parameters\n",
     "    ----------\n",
     "    diff_image : ndarray of floats\n",
@@ -763,7 +711,7 @@
     "    gradient_cutoff : float\n",
     "        Controls how far out of parallel lines can be to edges before\n",
     "        correction is terminated. The default (2.) is good for most cases.\n",
-    "        \n",
+    "\n",
     "    Returns\n",
     "    -------\n",
     "    costs_arr : ndarray of floats\n",
@@ -772,45 +720,50 @@
     "    if vertical is not True:\n",
     "        return tweak_costs(diff_image.T, mask.T, vertical=vertical,\n",
     "                           gradient_cutoff=gradient_cutoff).T\n",
-    "    \n",
+    "\n",
     "    # Start with a high-cost array of 1's\n",
     "    costs_arr = np.ones_like(diff_image)\n",
-    "    \n",
+    "\n",
     "    # Obtain extent of overlap\n",
     "    row, col = mask.nonzero()\n",
     "    cmin = col.min()\n",
     "    cmax = col.max()\n",
+    "    shape = mask.shape\n",
     "\n",
     "    # Label discrete regions\n",
+    "    labels = mask.copy().astype(np.uint8)\n",
     "    cslice = slice(cmin, cmax + 1)\n",
-    "    labels = label(mask[:, cslice])\n",
-    "    \n",
+    "    submask = np.ascontiguousarray(labels[:, cslice])\n",
+    "    submask = flood_fill(submask, (0, 0), 2)\n",
+    "    submask = flood_fill(submask, (shape[0]-1, 0), 3)\n",
+    "    labels[:, cslice] = submask\n",
+    "\n",
     "    # Find distance from edge to region\n",
-    "    upper = (labels == 0).sum(axis=0)\n",
-    "    lower = (labels == 2).sum(axis=0)\n",
-    "    \n",
+    "    upper = (labels == 2).sum(axis=0).astype(np.float64)\n",
+    "    lower = (labels == 3).sum(axis=0).astype(np.float64)\n",
+    "\n",
     "    # Reject areas of high change\n",
-    "    ugood = np.abs(np.gradient(upper)) < gradient_cutoff\n",
-    "    lgood = np.abs(np.gradient(lower)) < gradient_cutoff\n",
-    "    \n",
+    "    ugood = np.abs(np.gradient(upper[cslice])) < gradient_cutoff\n",
+    "    lgood = np.abs(np.gradient(lower[cslice])) < gradient_cutoff\n",
+    "\n",
     "    # Give areas slightly farther from edge a cost break\n",
-    "    costs_upper = np.ones_like(upper, dtype=np.float64)\n",
-    "    costs_lower = np.ones_like(lower, dtype=np.float64)\n",
-    "    costs_upper[ugood] = upper.min() / np.maximum(upper[ugood], 1)\n",
-    "    costs_lower[lgood] = lower.min() / np.maximum(lower[lgood], 1)\n",
-    "    \n",
+    "    costs_upper = np.ones_like(upper)\n",
+    "    costs_lower = np.ones_like(lower)\n",
+    "    costs_upper[cslice][ugood] = upper[cslice].min() / np.maximum(upper[cslice][ugood], 1)\n",
+    "    costs_lower[cslice][lgood] = lower[cslice].min() / np.maximum(lower[cslice][lgood], 1)\n",
+    "\n",
     "    # Expand from 1d back to 2d\n",
     "    vdist = mask.shape[0]\n",
     "    costs_upper = costs_upper[np.newaxis, :].repeat(vdist, axis=0)\n",
     "    costs_lower = costs_lower[np.newaxis, :].repeat(vdist, axis=0)\n",
-    "    \n",
+    "\n",
     "    # Place these in output array\n",
-    "    costs_arr[:, cslice] = costs_upper * (labels == 0)\n",
-    "    costs_arr[:, cslice] +=  costs_lower * (labels == 2)\n",
-    "    \n",
+    "    costs_arr[:, cslice] = costs_upper[:, cslice] * (labels[:, cslice] == 2)\n",
+    "    costs_arr[:, cslice] +=  costs_lower[:, cslice] * (labels[:, cslice] == 3)\n",
+    "\n",
     "    # Finally, place the difference image\n",
     "    costs_arr[mask] = diff_image[mask]\n",
-    "    \n",
+    "\n",
     "    return costs_arr"
    ]
   },
@@ -824,9 +777,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Start with the absolute value of the difference image.\n",
@@ -845,9 +796,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "costs01[0,  :] = 0\n",
@@ -864,9 +813,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(15, 12))\n",
@@ -895,9 +842,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.graph import route_through_array\n",
@@ -923,9 +868,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -972,9 +915,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Start with an array of zeros and place the path\n",
@@ -992,9 +933,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(11, 11))\n",
@@ -1015,15 +954,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from skimage.measure import label\n",
+    "from skimage.morphology import flood_fill\n",
     "\n",
     "# Labeling starts with one at point (0, 0)\n",
-    "mask0 = (label(mask0, connectivity=1, background=-1) == 1)\n",
+    "mask0 = flood_fill(mask0, (0, 0), 1, connectivity=1)\n",
     "\n",
     "# The result\n",
     "plt.imshow(mask0, cmap='gray');"
@@ -1043,9 +980,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Start with the absolute value of the difference image.\n",
@@ -1069,9 +1004,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "costs12[mask0 > 0] = 1"
@@ -1087,9 +1020,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(8, 8))\n",
@@ -1108,9 +1039,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Arguments are:\n",
@@ -1134,9 +1063,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -1160,9 +1087,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mask2 = np.zeros_like(pano0_warped, dtype=np.uint8)\n",
@@ -1179,12 +1104,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "mask2 = (label(mask2, connectivity=1, background=-1) == 3)\n",
+    "mask2 = flood_fill(mask2, (rmax, cmax), 1, connectivity=1)\n",
     "\n",
     "# The result\n",
     "plt.imshow(mask2, cmap='gray');"
@@ -1202,12 +1125,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "mask1 = ~(mask0 | mask2).astype(bool)"
+    "mask1 = ~(mask0.astype(np.bool) | mask2.astype(np.bool))"
    ]
   },
   {
@@ -1220,9 +1141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def add_alpha(img, mask=None):\n",
@@ -1257,9 +1176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pano0_final = add_alpha(pano0_warped, mask0)\n",
@@ -1281,9 +1198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -1321,9 +1236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Identical transforms as before, except\n",
@@ -1349,9 +1262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pano0_final = add_alpha(pano0_color, mask0)\n",
@@ -1369,9 +1280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12, 12))\n",
@@ -1395,9 +1304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from skimage.color import gray2rgb\n",
@@ -1419,9 +1326,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "\n",
     "---\n",
@@ -1431,9 +1336,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "<div style=\"height: 400px;\"></div>"
    ]
@@ -1467,9 +1370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%reload_ext load_style\n",
@@ -1479,9 +1380,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -1502,9 +1401,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Supersedes and closes #23.  

The panorama tutorial no longer uses `label` as a backwards method of flood filling, instead directly using `flood_fill`.  Tested and now completely working.