### PR TITLE
Replacing `scipy.stats.scoreatpercentile` with `numpy.percentile`

### DIFF
--- a/lectures/three_dimensional_image_processing.ipynb
+++ b/lectures/three_dimensional_image_processing.ipynb
@@ -14,7 +14,6 @@
     "import numpy as np\n",
     "\n",
     "from scipy import ndimage as ndi\n",
-    "from scipy import stats\n",
     "\n",
     "from skimage import (exposure, feature, filters, io, measure,\n",
     "                      morphology, restoration, segmentation, transform,\n",
@@ -564,7 +563,7 @@
     }
    ],
    "source": [
-    "vmin, vmax = stats.scoreatpercentile(data, (0.5, 99.5))\n",
+    "vmin, vmax = np.percentile(data, q=(0.5, 99.5))\n",
     "\n",
     "clipped = exposure.rescale_intensity(\n",
     "    data, \n",


### PR DESCRIPTION
As stated in [`sp.stats.scoreatpercentile` docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.scoreatpercentile.html),

> This function will become obsolete in the future. For NumPy 1.9 and higher, numpy.percentile provides all the functionality that scoreatpercentile provides. And it’s significantly faster. Therefore it’s recommended to use numpy.percentile for users that have numpy >= 1.9.