### PR TITLE
Rename branch from master to main in files and URLs to match git tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A collection of tutorials for the [scikit-image](http://skimage.org) package.
 
 Launch the tutorial notebooks directly with MyBinder now:
 
-[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/scikit-image/skimage-tutorials/master?filepath=index.ipynb)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/scikit-image/skimage-tutorials/main?filepath=index.ipynb)
 
 Or you can setup and run on your local machine:
 1. [Follow the preparation instructions](preparation.md)

--- a/_sources/imagexd.txt
+++ b/_sources/imagexd.txt
@@ -44,9 +44,9 @@ Schedule
 - 14:00—14:30  :doc:`scikit-image: images are arrays <lessons/0_images_are_arrays>`
 - 14:30—14:45  Coffee break
 - 14:45—15:45  scikit-image: `filtering
-  <http://nbviewer.jupyter.org/github/scikit-image/skimage-tutorials/blob/master/book/lessons/1_image_filters.ipynb>`__
+  <http://nbviewer.jupyter.org/github/scikit-image/skimage-tutorials/blob/main/book/lessons/1_image_filters.ipynb>`__
   and `segmentation
-  <http://nbviewer.jupyter.org/github/scikit-image/skimage-tutorials/blob/master/book/lessons/4_segmentation.ipynb>`__
+  <http://nbviewer.jupyter.org/github/scikit-image/skimage-tutorials/blob/main/book/lessons/4_segmentation.ipynb>`__
 - 15:45—16:15  :doc:`scikit-image: RANSAC <lessons/1_ransac>`
 - 16:15—16:25  Coffee break
 - 16:25—16:30  Panorama demo

--- a/_sources/lessons/0_installation.txt
+++ b/_sources/lessons/0_installation.txt
@@ -75,6 +75,6 @@ attendees.**
 There are two ways of downloading the lecture materials:
 
 a) Get the `ZIP file from GitHub
-   <https://github.com/scikit-image/skimage-tutorials/archive/master.zip>`__
+   <https://github.com/scikit-image/skimage-tutorials/archive/main.zip>`__
 b) Clone the repository at
    https://github.com/scikit-image/skimage-tutorial

--- a/_sources/lessons/0_preparation.txt
+++ b/_sources/lessons/0_preparation.txt
@@ -72,6 +72,6 @@ attendees.**
 
 There are two ways of downloading the lecture materials:
 
-1. Get the [ZIP file from GitHub](https://github.com/scikit-image/skimage-tutorials/archive/master.zip)
+1. Get the [ZIP file from GitHub](https://github.com/scikit-image/skimage-tutorials/archive/main.zip)
 2. Clone the repository at
     [https://github.com/scikit-image/skimage-tutorials](https://github.com/scikit-image/skimage-tutorials)

--- a/workshops/2014-euroscipy/index.ipynb
+++ b/workshops/2014-euroscipy/index.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "- Follow the project's progress [on GitHub](https://github.com/scikit-image/scikit-image).\n",
     "- Ask the team questions on the [mailing list](https://groups.google.com/d/forum/scikit-image)\n",
-    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/master/CONTRIBUTING.txt)\n",
+    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/main/CONTRIBUTING.txt)\n",
     "- If you find it useful: cite [our paper](https://peerj.com/articles/453/)!"
    ]
   }

--- a/workshops/2014-scipy/000_index.ipynb
+++ b/workshops/2014-scipy/000_index.ipynb
@@ -75,7 +75,7 @@
     "\n",
     "- Follow the project's progress [on GitHub](https://github.com/scikit-image/scikit-image).\n",
     "- Ask the team questions on the [mailing list](https://groups.google.com/d/forum/scikit-image)\n",
-    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/master/CONTRIBUTING.txt)\n",
+    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/main/CONTRIBUTING.txt)\n",
     "- If you find it useful: cite [our paper](https://peerj.com/articles/453/)!"
    ]
   }

--- a/workshops/2015-scipy/index.ipynb
+++ b/workshops/2015-scipy/index.ipynb
@@ -117,7 +117,7 @@
     "\n",
     "- Follow the project's progress [on GitHub](https://github.com/scikit-image/scikit-image).\n",
     "- Ask the team questions on the [mailing list](https://groups.google.com/d/forum/scikit-image).\n",
-    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/master/CONTRIBUTING.txt)\n",
+    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/main/CONTRIBUTING.txt)\n",
     "- If you find it useful: please [cite our paper](https://peerj.com/articles/453/)!\n",
     "\n",
     "---"

--- a/workshops/2015-strata/index.ipynb
+++ b/workshops/2015-strata/index.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "- Follow the project's progress [on GitHub](https://github.com/scikit-image/scikit-image).\n",
     "- Ask the team questions on the [mailing list](https://groups.google.com/d/forum/scikit-image)\n",
-    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/master/CONTRIBUTING.txt)\n",
+    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/main/CONTRIBUTING.txt)\n",
     "- If you find it useful: cite [our paper](https://peerj.com/articles/453/)!"
    ]
   },

--- a/workshops/2016-scipy/000_index.ipynb
+++ b/workshops/2016-scipy/000_index.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "- Follow the project's progress [on GitHub](https://github.com/scikit-image/scikit-image).\n",
     "- Ask the team questions on the [mailing list](https://groups.google.com/d/forum/scikit-image)\n",
-    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/master/.github/CONTRIBUTING.txt)\n",
+    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/main/.github/CONTRIBUTING.txt)\n",
     "- Read [our paper](https://peerj.com/articles/453/)!"
    ]
   }

--- a/workshops/2017-odsc/000_index.ipynb
+++ b/workshops/2017-odsc/000_index.ipynb
@@ -42,7 +42,7 @@
     "\n",
     "# Prerequisites\n",
     "\n",
-    "Please refer to the [preparation instructions](https://github.com/scikit-image/skimage-tutorials/blob/master/preparation.md).\n",
+    "Please refer to the [preparation instructions](https://github.com/scikit-image/skimage-tutorials/blob/main/preparation.md).\n",
     "\n",
     "\n",
     "# Sections\n",
@@ -82,7 +82,7 @@
     "\n",
     "- Follow the project's progress [on GitHub](https://github.com/scikit-image/scikit-image).\n",
     "- Ask the team questions on the [mailing list](https://mail.python.org/mailman/listinfo/scikit-image)\n",
-    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/master/.github/CONTRIBUTING.txt)\n",
+    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/main/.github/CONTRIBUTING.txt)\n",
     "- Read [our paper](https://peerj.com/articles/453/) (or [this one, for skimage in microscopy](https://ascimaging.springeropen.com/articles/10.1186/s40679-016-0031-0))"
    ]
   },

--- a/workshops/2017-scipy/000_index.ipynb
+++ b/workshops/2017-scipy/000_index.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "- Follow the project's progress [on GitHub](https://github.com/scikit-image/scikit-image).\n",
     "- Ask the team questions on the [mailing list](https://mail.python.org/mailman/listinfo/scikit-image)\n",
-    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/master/.github/CONTRIBUTING.txt)\n",
+    "- [Contribute!](https://github.com/scikit-image/scikit-image/blob/main/.github/CONTRIBUTING.txt)\n",
     "- Read [our paper](https://peerj.com/articles/453/) (or [this one, for skimage in microscopy](https://ascimaging.springeropen.com/articles/10.1186/s40679-016-0031-0))"
    ]
   },

--- a/workshops/2018-scipy/index.ipynb
+++ b/workshops/2018-scipy/index.ipynb
@@ -40,7 +40,7 @@
     "\n",
     "# Prerequisites\n",
     "\n",
-    "Please see the [preparation instructions](https://github.com/scikit-image/skimage-tutorials/blob/master/preparation.md).\n",
+    "Please see the [preparation instructions](https://github.com/scikit-image/skimage-tutorials/blob/main/preparation.md).\n",
     "\n",
     "# Schedule\n",
     "\n",

--- a/workshops/2019-euroscipy/README.md
+++ b/workshops/2019-euroscipy/README.md
@@ -2,7 +2,7 @@
 
 * Support material for the tutorial _3D image processing with scikit-image_.
 
-Open it using Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/alexdesiqueira/tutorials/master)
+Open it using Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/alexdesiqueira/tutorials/main)
 
 Inside Binder's structure, please point to `/2019/euroscipy2019`.
 

--- a/workshops/2019-euroscipy/euroscipy2019_skimage.ipynb
+++ b/workshops/2019-euroscipy/euroscipy2019_skimage.ipynb
@@ -1524,7 +1524,7 @@
     "* `segmentation.felzenszwalb`\n",
     "* `segmentation.chan_vese`\n",
     "\n",
-    "There are also some supervised and unsupervised thresholding algorithms in `filters`. There is a [segmentation lecture](https://github.com/scikit-image/skimage-tutorials/blob/master/lectures/4_segmentation.ipynb) ([and its solution](https://github.com/scikit-image/skimage-tutorials/blob/master/lectures/solutions/4_segmentation.ipynb)) you may peruse, as well as many [gallery examples](https://scikit-image.org/docs/stable/auto_examples/index.html#segmentation-of-objects) which illustrate all of these segmentation methods.\n",
+    "There are also some supervised and unsupervised thresholding algorithms in `filters`. There is a [segmentation lecture](https://github.com/scikit-image/skimage-tutorials/blob/main/lectures/4_segmentation.ipynb) ([and its solution](https://github.com/scikit-image/skimage-tutorials/blob/main/lectures/solutions/4_segmentation.ipynb)) you may peruse, as well as many [gallery examples](https://scikit-image.org/docs/stable/auto_examples/index.html#segmentation-of-objects) which illustrate all of these segmentation methods.\n",
     "\n",
     "[Feature extraction](https://en.wikipedia.org/wiki/Feature_extraction) reduces data required to describe an image or objects by measuring informative features. These include features such as area or volume, bounding boxes, and intensity statistics.\n",
     "\n",
@@ -1832,7 +1832,7 @@
    "source": [
     "## Going beyond\n",
     "\n",
-    "[1] A tour/guide on scikit-image's submodules: https://github.com/scikit-image/skimage-tutorials/blob/master/lectures/tour_of_skimage.ipynb\n",
+    "[1] A tour/guide on scikit-image's submodules: https://github.com/scikit-image/skimage-tutorials/blob/main/lectures/tour_of_skimage.ipynb\n",
     "\n",
     "[2] scikit-image's gallery examples: https://scikit-image.org/docs/stable/auto_examples/\n",
     "\n",

--- a/workshops/2019-euroscipy/setup.md
+++ b/workshops/2019-euroscipy/setup.md
@@ -28,7 +28,7 @@ Then, to activate this environment,
 
 ` $ conda activate euroscipy2019_skimage`
 
-To come back to your master environment,
+To come back to your base environment,
 
 `$ conda activate`
 

--- a/workshops/2019-monash-data-fluency/index.ipynb
+++ b/workshops/2019-monash-data-fluency/index.ipynb
@@ -39,7 +39,7 @@
     "\n",
     "# Prerequisites\n",
     "\n",
-    "Please see the [preparation instructions](https://github.com/scikit-image/skimage-tutorials/blob/master/preparation.md).\n",
+    "Please see the [preparation instructions](https://github.com/scikit-image/skimage-tutorials/blob/main/preparation.md).\n",
     "\n",
     "# Schedule\n",
     "\n",

--- a/workshops/2019-scipy/index.ipynb
+++ b/workshops/2019-scipy/index.ipynb
@@ -68,7 +68,7 @@
     "\n",
     "# Prerequisites\n",
     "\n",
-    "Please see the [preparation instructions](https://github.com/scikit-image/skimage-tutorials/blob/master/preparation.md).\n",
+    "Please see the [preparation instructions](https://github.com/scikit-image/skimage-tutorials/blob/main/preparation.md).\n",
     "\n",
     "# Schedule\n",
     "\n",


### PR DESCRIPTION
This PR brings the repo files in line with the branch name.

I went to fire up the binder server and got the error message "Could not resolve ref..." due to the `master` branch having been renamed to `main`, so I went ahead and renamed all instances such as repo zip URLs (and one which was a reference to "conda master" which is actually "base") [and leaving the references to 'master' inside jquery javascript unchanged].