### PR TITLE
Update toc using jb toc migrate.

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,6 +1,7 @@
-- file: lectures/00_images_are_arrays
+format: jb-article
+root: lectures/00_images_are_arrays
+sections:
 - file: lectures/1_image_filters
 - file: lectures/3_morphological_operations
 - file: lectures/4_segmentation
 - file: lectures/three_dimensional_image_processing
-


### PR DESCRIPTION
Closes #64 

At least gets the jupyter-book workflow running. There are still failures in the build process, but it at least gets the build running.

This is the result of running `jb toc migrate` as recommended at the very end of the error message posted in #64 (I missed this in the first readthrough of the error).