### PR TITLE
Update malformed _toc.yml to fix jupyter-book build in CI

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,6 +1,7 @@
-- file: lectures/00_images_are_arrays
+format: jb-article
+root: lectures/00_images_are_arrays
+sections:
 - file: lectures/1_image_filters
 - file: lectures/3_morphological_operations
 - file: lectures/4_segmentation
 - file: lectures/three_dimensional_image_processing
-


### PR DESCRIPTION
Running jupyter-book build . with v0.13.0 fails with the following
message:

```
The Table of Contents file is malformed: toc is not a mapping: <class 'list'>
You may need to migrate from the old format, using:

	jupyter-book toc migrate _toc.yml -o _toc.yml
```

After updating _toc.yml accordingly, the build succeeds.

cc @emmanuelle 